### PR TITLE
updated Dockerfile to debian-stretch to minimize security vulnerabili…

### DIFF
--- a/3dsrelay/Dockerfile
+++ b/3dsrelay/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM debian:stretch
 
 RUN apt-get update && apt-get install -y \
     dnsutils \


### PR DESCRIPTION
This change addresses all security vulnerabilities that are not covered in ubuntu:16.04 image but area already addressed in debian:stretch image.